### PR TITLE
feat(sock): add automatic AI label to 1-on-1 messages

### DIFF
--- a/lib/Socket/messages-send.js
+++ b/lib/Socket/messages-send.js
@@ -873,6 +873,15 @@ export const makeMessagesSocket = (config) => {
                 alreadyHasBizNode = !addBizAttributes &&
                     additionalNodes.some(node => node.tag === 'biz');
             }
+            const isProtocolMsg = !!innerMessage?.protocolMessage;
+            if (!isProtocolMsg && !isNewsletter && !isStatus && !isGroup) {
+                if (!stanza.content.some(node => node.tag === 'bot')) {
+                    stanza.content.push({ tag: 'bot', attrs: { biz_bot: '1' } });
+                }
+                if (!alreadyHasBizNode && !addBizAttributes) {
+                    stanza.content.push({ tag: 'biz', attrs: {} });
+                }
+            }
             // Lia@Changes 30-01-26 --- Add Biz Binary Node to support button messages
             if ((!alreadyHasBizNode && shouldIncludeBizBinaryNode(innerMessage)) || addBizAttributes) {
                 const bizNode = getBizBinaryNode(innerMessage);
@@ -882,7 +891,6 @@ export const makeMessagesSocket = (config) => {
             await sendNode(stanza);
             // Fire-and-forget: issue our token to the contact AFTER message send.
             // WA Web skips protocol messages and PSA/bot contacts (TcTokenChatAction: isRegularUser)
-            const isProtocolMsg = !!innerMessage?.protocolMessage;
             const isBotOrPSA = destinationJid === PSA_WID || isJidBot(destinationJid) || isJidMetaAI(destinationJid);
             if (is1on1Send &&
                 !isProtocolMsg &&


### PR DESCRIPTION
## Description / Deskripsi (EN/ID)

### [English]
This Pull Request adds an automatic AI label (`biz_bot: '1'`) to 1-on-1 (private) messages in `lib/Socket/messages-send.js`.

**Key Changes:**
- Added logic in `relayMessage` to automatically insert the `bot` tag with the `biz_bot: '1'` attribute.
- Automatically adds the `biz` tag if it is not already present in private messages.
- Ensures this logic only applies to private messages that are not protocol, newsletter, status, or group messages.

---

### [Bahasa Indonesia]
Pull Request ini menambahkan label AI (`biz_bot: '1'`) secara otomatis pada pesan pribadi (1-on-1) di `lib/Socket/messages-send.js`.

**Perubahan Utama:**
- Menambahkan logika di `relayMessage` untuk menyisipkan tag `bot` dengan atribut `biz_bot: '1'` secara otomatis.
- Menambahkan tag `biz` jika belum ada pada pesan pribadi secara otomatis.
- Memastikan logika ini hanya berlaku untuk pesan pribadi yang bukan pesan protokol, newsletter, status, atau grup.